### PR TITLE
allow custom client

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const AWS = require('aws-sdk');
 module.exports = class LambdaInvoker {
   constructor(options) {
     options = options || {};
-    this._client = new AWS.Lambda();
+    this._client = options.client || new AWS.Lambda();
     this.logger = options.logger;
   }
 


### PR DESCRIPTION
We needed to specify custom parameters to the aws.lambda constructor.  Seemed like the easiest way around this was to provide an option to provide our own and default if none is provided